### PR TITLE
fix for query.find?

### DIFF
--- a/lib/nstore/query.js
+++ b/lib/nstore/query.js
@@ -18,8 +18,10 @@ module.exports = function QueryPlugin() {
       var keys = Object.keys(this.index);
       var counter = keys.length;
 	  if(keys.length === 0) {
-		  if (stream) stream.emit('end');
-		  if (callback) callback(null, results);
+		  process.nextTick(function() {
+			  if (stream) stream.emit('end');
+			  if (callback) callback(null, results);
+		  });
 	  } else { 
 		  keys.forEach(function (key) {
 			  this.get(key, function (err, doc, key) {

--- a/lib/nstore/query.js
+++ b/lib/nstore/query.js
@@ -17,24 +17,29 @@ module.exports = function QueryPlugin() {
       }
       var keys = Object.keys(this.index);
       var counter = keys.length;
-      keys.forEach(function (key) {
-        this.get(key, function (err, doc, key) {
-          if (err) {
-            if (stream) stream.emit('error', err);
-            if (callback) callback(err);
-            return;
-          }
-          if (filter(doc, key)) {
-            if (stream) stream.emit('document', doc, key);
-            if (callback) results[key] = doc;
-          };
-          counter--;
-          if (counter === 0) {
-            if (stream) stream.emit('end');
-            if (callback) callback(null, results);
-          }
-        });
-      }, this);
+	  if(keys.length === 0) {
+		  if (stream) stream.emit('end');
+		  if (callback) callback(null, results);
+	  } else { 
+		  keys.forEach(function (key) {
+			  this.get(key, function (err, doc, key) {
+				  if (err) {
+					  if (stream) stream.emit('error', err);
+					  if (callback) callback(err);
+					  return;
+				  }
+				  if (filter(doc, key)) {
+					  if (stream) stream.emit('document', doc, key);
+					  if (callback) results[key] = doc;
+				  };
+				  counter--;
+				  if (counter === 0) {
+					  if (stream) stream.emit('end');
+					  if (callback) callback(null, results);
+				  }
+			  });
+		  }, this);
+	  }
     }
 
   };

--- a/test/findAllTest.js
+++ b/test/findAllTest.js
@@ -1,0 +1,13 @@
+require('./helper');
+nStore = nStore.extend(require('nstore/query')());
+
+
+expect("load");
+var store = nStore.new('fixtures/new.db', function () {
+	expect("all");
+	fulfill("load");
+	Step(
+		function() { store.all(this); },
+		function() { fulfill("all"); } 
+	);
+});


### PR DESCRIPTION
Hi,

I used store.all on a newly created i.e. empty store. My expected callback was not being called, due to the query#find implementation that only calls callback when keys are present. Here is a test and fix
