### PR TITLE
0.2.1 branch for node 0.4.3

### DIFF
--- a/lib/nstore.js
+++ b/lib/nstore.js
@@ -21,6 +21,7 @@ function fsRead(fd, position, length, callback) {
       offset = 0;
 
   function readChunk() {
+    debugger
     fs.read(fd, buffer, offset, length - offset, position, function (err, bytesRead) {
       if (err) { callback(err); return; }
 
@@ -182,7 +183,7 @@ function nStore(filename, filterFn, isTemp) {
 
     // Create an empty stream buffer
     var input = new Buffer(MAX_SIZE);
-    input.length = 0;
+    var input_length = 0;
 
     // These are positions in the database file
     var offset = 0;
@@ -199,11 +200,11 @@ function nStore(filename, filterFn, isTemp) {
       offset += chunk.length;
 
       // Copy the chunk onto the input stream
-      chunk.copy(input, input.length, 0, chunk.length);
-      input.length += chunk.length;
+      chunk.copy(input, input_length, 0, chunk.length);
+      input_length += chunk.length;
 
       // See if there is input to consume
-      for (var i = pos, l = input.length; i < l; i++) {
+      for (var i = pos, l = input_length; i < l; i++) {
         if (input[i] === 9) {
           mid = i + 1;
         }
@@ -231,7 +232,7 @@ function nStore(filename, filterFn, isTemp) {
       // Shift the input back down
       if (pos > 0) {
         input.copy(input, 0, pos, input.length);
-        input.length -= pos;
+        input_length -= pos;
         base += pos;
         pos = 0;
       }

--- a/lib/nstore.js
+++ b/lib/nstore.js
@@ -21,7 +21,6 @@ function fsRead(fd, position, length, callback) {
       offset = 0;
 
   function readChunk() {
-    debugger
     fs.read(fd, buffer, offset, length - offset, position, function (err, bytesRead) {
       if (err) { callback(err); return; }
 


### PR DESCRIPTION
Hi Tim,

your nStore implementation fails for me on node 0.4.3.
I tracked down the issue to when you set the input buffer length to 0. It seems to me, that newer versions of node 
a) don't allow this
b) there is a bug in node

anyways it never returns from there.
I fixed the issue by using a separate variable input_length to track the position in the buffer.

Also I see, that you did some major refactoring and 0.3.0 is still unstable, so I decided to fix 0.2.1 in the meanwhile.
Hope this is appreciated.

Best regards

Gregor
