### PR TITLE
Prevent error that happens when trying to read a value that was deleted before

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nstore.js
+++ b/nstore.js
@@ -159,7 +159,7 @@ var nStore = module.exports = Pattern.extend({
     // Read from disk otherwise
     try {
       var info = this.index[key];
-      if (!info) {
+      if (!info || info.length == 0) {
         missing();
         return;
       }


### PR DESCRIPTION
The index array saves a value with the length 0. When trying to read this value again JSON.parse fails. This commit prevents it from trying to parse the 0 length value. Instead it throws the same exception that gets thrown if a value doesn't exist

The other commit is just a .gitignore file with node_modules in it. This helps developing cause you can install the dependencies localy with npm
