### PR TITLE
Fix remove. 

### DIFF
--- a/nstore.js
+++ b/nstore.js
@@ -235,6 +235,7 @@ var nStore = module.exports = Pattern.extend({
           if (self.index.hasOwnProperty(key)) {
             self.stale++;
             if (value.length === 0) {
+              value = undefined;
               delete self.index[key];
             }
           }


### PR DESCRIPTION
The document was being deleted off of the index on the checkQueue update. 

But the iterator wasn't being nulled so `if(value !== undefined)` wasn't preventing the document's index from being re-set on `self.index` and subsequent query.all's were failing.

I just added a `value = undefined` to the delete logic.
