### PR TITLE
fix: set next variable to local instead of global

### DIFF
--- a/nstore.js
+++ b/nstore.js
@@ -69,7 +69,7 @@ var nStore = module.exports = Pattern.extend({
             switch (buffer[i]) {
               case TAB:
                 line[1] = position + i;
-                next = NEWLINE;
+                var next = NEWLINE;
                 break;
               case NEWLINE:
                 line[2] = position + i;


### PR DESCRIPTION
Hi,
mocha detected a global leak, so I set it to local. But as far as I can see `next` isn't used anyway?!
Cheers Philipp 
