### PR TITLE
replace process.ENOENT by constants.ENOENT

### DIFF
--- a/nstore.js
+++ b/nstore.js
@@ -1,6 +1,7 @@
 var Path = require('path'),
     Fs = require('fs'),
     Step = require('step'),
+    Constants = require('constants'),
     Pattern = require('pattern'),
     Hash = require('pattern/hash'),
     Queue = require('pattern/queue'),
@@ -135,7 +136,7 @@ var nStore = module.exports = Pattern.extend({
   get: function getByKey(key, callback) {
     function missing() {
       var error = new Error("Document does not exist for " + key);
-      error.errno = process.ENOENT;
+      error.errno = Constants.ENOENT;
       callback(error);
     }
     // Check the cache of just written values
@@ -320,7 +321,7 @@ var nStore = module.exports = Pattern.extend({
       var info = this.index[key];
       if (!info) {
         var error = new Error("Document does not exist for " + key);
-        error.errno = process.ENOENT;
+        error.errno = Constants.ENOENT;
         callback(error);
         return;
       }

--- a/test/getTest.js
+++ b/test/getTest.js
@@ -1,3 +1,5 @@
+var Constants = require('constants');
+
 require('./helper');
 
 expect("load");
@@ -23,8 +25,8 @@ var users = nStore.new('fixtures/sample.db', function () {
   users.get("bob", function (err, doc, key) {
     fulfill("get missing");
     assert.ok(err instanceof Error, "error should be an Error");
-    if (err.errno !== process.ENOENT) throw err;
-    assert.equal(err.errno, process.ENOENT, "Error instance should be ENOENT");
+    if (err.errno !== Constants.ENOENT) throw err;
+    assert.equal(err.errno, Constants.ENOENT, "Error instance should be ENOENT");
     assert.ok(!doc, "no doc loaded");
     assert.ok(!key, "no key loaded");
   });

--- a/test/removeTest.js
+++ b/test/removeTest.js
@@ -1,3 +1,5 @@
+var Constants = require('constants');
+
 require('./helper');
 
 expect("load");
@@ -14,7 +16,7 @@ var users = nStore.new('fixtures/toDelete.db', function () {
     users.get("creationix", function (err, doc, meta) {
       fulfill("get fail");
       assert.ok(err instanceof Error, "error is an Error");
-      assert.equal(err.errno, process.ENOENT, "Error instance should be ENOENT");
+      assert.equal(err.errno, Constants.ENOENT, "Error instance should be ENOENT");
       assert.ok(!doc, "no doc loaded");
       assert.ok(!meta, "no meta loaded");
     });
@@ -37,7 +39,7 @@ var users = nStore.new('fixtures/toDelete.db', function () {
   users.remove("baduser", function (err) {
       fulfill("fail");
       assert.ok(err instanceof Error, "error is an Error");
-      if (err.errno !== process.ENOENT) throw err;
+      if (err.errno !== Constants.ENOENT) throw err;
   });
 });
 


### PR DESCRIPTION
"Constants moved from process object to require('constants')" in Version 0.3.0 (http://nodejs.org/changelog.html)
